### PR TITLE
Roles fix

### DIFF
--- a/lib/capistrano/tasks/maintenance.rake
+++ b/lib/capistrano/tasks/maintenance.rake
@@ -1,19 +1,23 @@
 namespace :maintenance do
 
-  task :enable, :roles => :web do
-    require 'erb'
-    on_rollback { run "rm -f #{shared_path}/system/#{maintenance_basename}.html" }
+  task :enable do
+    on roles(:web) do
+      require 'erb'
+      on_rollback { run "rm -f #{shared_path}/system/#{maintenance_basename}.html" }
 
-    reason = ENV['REASON']
-    deadline = ENV['UNTIL']
+      reason = ENV['REASON']
+      deadline = ENV['UNTIL']
 
-    template = File.read(maintenance_template_path)
-    result = ERB.new(template).result(binding)
+      template = File.read(maintenance_template_path)
+      result = ERB.new(template).result(binding)
 
-    put result, "#{shared_path}/system/#{maintenance_basename}.html", :mode => 0644
+      put result, "#{shared_path}/system/#{maintenance_basename}.html", :mode => 0644
+    end
   end
 
-  task :disable, :roles => :web do
-    run "rm -f #{shared_path}/system/#{maintenance_basename}.html"
+  task :disable do
+    on roles(:web) do
+      run "rm -f #{shared_path}/system/#{maintenance_basename}.html"
+    end
   end
 end


### PR DESCRIPTION
Fix the following error, with incorrect roles set:

```
$ cap production maintenance:enable --trace
cap aborted!
undefined method `map' for :roles:Symbol
/home/vagrant/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/task.rb:304:in `set_arg_names'
/home/vagrant/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/task_manager.rb:29:in `define_task'
/home/vagrant/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/task.rb:360:in `define_task'
/home/vagrant/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/dsl_definition.rb:32:in `task'
/home/vagrant/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/bundler/gems/capistrano-maintenance-c53a4605bdae/lib/capistrano/tasks/maintenance.rake:3:in `block in <top (required)>'
/home/vagrant/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/task_manager.rb:196:in `in_namespace'
/home/vagrant/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/dsl_definition.rb:104:in `namespace'
/home/vagrant/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/bundler/gems/capistrano-maintenance-c53a4605bdae/lib/capistrano/tasks/maintenance.rake:1:in `<top (required)>'
/home/vagrant/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/bundler/gems/capistrano-maintenance-c53a4605bdae/lib/capistrano/maintenance.rb:1:in `load'
/home/vagrant/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/bundler/gems/capistrano-maintenance-c53a4605bdae/lib/capistrano/maintenance.rb:1:in `<top (required)>'
/vagrant/Capfile:24:in `require'
/vagrant/Capfile:24:in `<top (required)>'
/home/vagrant/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/rake_module.rb:25:in `load'
/home/vagrant/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/rake_module.rb:25:in `load_rakefile'
/home/vagrant/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/application.rb:637:in `raw_load_rakefile'
/home/vagrant/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/application.rb:94:in `block in load_rakefile'
/home/vagrant/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/application.rb:165:in `standard_exception_handling'
/home/vagrant/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/application.rb:93:in `load_rakefile'
/home/vagrant/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/capistrano-3.0.1/lib/capistrano/application.rb:22:in `load_rakefile'
/home/vagrant/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/application.rb:77:in `block in run'
/home/vagrant/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/application.rb:165:in `standard_exception_handling'
/home/vagrant/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/rake-10.1.0/lib/rake/application.rb:75:in `run'
/home/vagrant/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/capistrano-3.0.1/lib/capistrano/application.rb:12:in `run'
/home/vagrant/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/capistrano-3.0.1/bin/cap:3:in `<top (required)>'
bin/cap:16:in `load'
bin/cap:16:in `<main>'
```

Also one question: Is not `on_rollback` removed in capistrano 3?
