### PR TITLE
Moving to Capistrano 3.1 and switching from 'system/shared' to 'current/...

### DIFF
--- a/lib/capistrano/tasks/maintenance.rake
+++ b/lib/capistrano/tasks/maintenance.rake
@@ -3,21 +3,22 @@ namespace :maintenance do
   task :enable do
     on roles(:web) do
       require 'erb'
-      on_rollback { run "rm -f #{shared_path}/system/#{maintenance_basename}.html" }
+      # Do we really need it? I see situations where removing maintenance page on rollback is wrong thing.
+      # on_rollback { execute "rm -f #{release_path}/public/#{fetch(:maintenance_basename, 'maintenance')}.html" }
 
       reason = ENV['REASON']
       deadline = ENV['UNTIL']
 
-      template = File.read(maintenance_template_path)
+      template = File.read(fetch(:maintenance_template_path))
       result = ERB.new(template).result(binding)
 
-      put result, "#{shared_path}/system/#{maintenance_basename}.html", :mode => 0644
+      upload! StringIO.new(result), "#{release_path}/public/#{fetch(:maintenance_basename, 'maintenance')}.html", :mode => 0644
     end
   end
 
   task :disable do
     on roles(:web) do
-      run "rm -f #{shared_path}/system/#{maintenance_basename}.html"
+      execute "rm -f #{release_path}/public/#{fetch(:maintenance_basename, 'maintenance')}.html"
     end
   end
 end


### PR DESCRIPTION
Ported to Capistrano 3 without backwards compatibility with Capistrano 2. Also decided to place maintenance page in `current/public` to make it compatible with Passenger.
