### PR TITLE
Don't disable maintenance mode on rollback

### DIFF
--- a/lib/capistrano/tasks/maintenance.rake
+++ b/lib/capistrano/tasks/maintenance.rake
@@ -3,7 +3,6 @@ namespace :maintenance do
   task :enable do
     on roles(:web) do
       require 'erb'
-      on_rollback { run "rm -f #{shared_path}/system/#{maintenance_basename}.html" }
 
       reason = ENV['REASON']
       deadline = ENV['UNTIL']


### PR DESCRIPTION
Maintenance mode should be turned off by `cap maintenance:disable` command only.
Fix #6.
