### PR TITLE
Fixes to make the gem work

### DIFF
--- a/lib/capistrano/tasks/maintenance.rake
+++ b/lib/capistrano/tasks/maintenance.rake
@@ -7,17 +7,20 @@ namespace :maintenance do
       reason = ENV['REASON']
       deadline = ENV['UNTIL']
 
-      template = File.read(maintenance_template_path)
-      result = ERB.new(template).result(binding)
+      default_template = File.join(File.expand_path('../../templates', __FILE__), 'maintenance.html.erb')
+      template = fetch(:maintenance_template_path, default_template)
+      result = ERB.new(File.read(template)).result(binding)
 
-      put result, "#{shared_path}/system/#{maintenance_basename}.html", :mode => 0644
+      rendered_path = "#{shared_path}/public/system/#{fetch(:maintenance_basename, 'maintenance')}.html"
+      upload!(StringIO.new(result), rendered_path)
+      execute "chmod 644 #{rendered_path}"
     end
   end
 
   desc "Turn off maintenance mode"
   task :disable do
     on roles(:web) do
-      run "rm -f #{shared_path}/system/#{maintenance_basename}.html"
+      execute "rm -f #{shared_path}/public/system/#{fetch(:maintenance_basename, 'maintenance')}.html"
     end
   end
 end

--- a/lib/capistrano/templates/maintenance.html.erb
+++ b/lib/capistrano/templates/maintenance.html.erb
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Maintenance</title>
+    <style type="text/css">
+    body {
+        width: 400px;
+        margin: 100px auto;
+        font: 300 120% "OpenSans", "Helvetica Neue", "Helvetica", Arial, Verdana, sans-serif;
+    }
+
+    h1 {
+        font-weight: 300;
+    }
+    </style>
+</head>
+<body>
+    <h1>Maintenance</h1>
+
+    <p>The system is down for <%= reason ? reason : "maintenance" %><br>
+           as of <%= Time.now.strftime("%H:%M %Z") %>.</p>
+
+    <p>It'll be back <%= deadline ? deadline : "shortly" %>.</p>
+</body>
+</html>


### PR DESCRIPTION
We are in the process of upgrading from cap v2 to cap v3 and routinely use the original cap v2 maintenance gem/tasks.  I was thrilled when I came across your cap v3 fork, but in testing the gem, it appears to be broken.  This PR incorporates several changes we needed in order to make this work:
- Use fetch() to pull maintenance_template_path and maintenance_basename, matching v2 behavior
- Use upload! to transfer the rendered template.
- Store the template in public/system, matching v2 behavior
- Add the v2 default template for people who don't override maintenance_template_path
