### PR TITLE
Add error_page declaration to example nginx conf.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Before using maintenance tasks, you need to configure webserver.
 Here is an example config for nginx:
 
 ```
+error_page 503 @503;
+
 if (-f $document_root/system/maintenance.html) {
   return 503;
 }


### PR DESCRIPTION
I was following the example and had to add this line to get the maintenance.html page to render. Otherwise the standard nginx 503 error was displayed.
