### PR TITLE
Show date in maintenance start timestamp

### DIFF
--- a/lib/capistrano/templates/maintenance.html.erb
+++ b/lib/capistrano/templates/maintenance.html.erb
@@ -18,7 +18,7 @@
     <h1>Maintenance</h1>
 
     <p>The system is down for <%= reason ? reason : "maintenance" %><br>
-           as of <%= Time.now.strftime("%H:%M %Z") %>.</p>
+           as of <%= Time.now.strftime("%F %H:%M %Z") %>.</p>
 
     <p>It'll be back <%= deadline ? deadline : "shortly" %>.</p>
 </body>


### PR DESCRIPTION
This will show "... as of 2014-03-27 14:29 CET."

![screen shot 2014-03-27 at 14 32 49](https://cloud.githubusercontent.com/assets/7913/2537705/5ade147c-b5b4-11e3-8362-9028583b480d.png)
