### PR TITLE
Check if directories exist before uploading

### DIFF
--- a/lib/capistrano/tasks/maintenance.rake
+++ b/lib/capistrano/tasks/maintenance.rake
@@ -11,9 +11,16 @@ namespace :maintenance do
       template = fetch(:maintenance_template_path, default_template)
       result = ERB.new(File.read(template)).result(binding)
 
-      rendered_path = "#{shared_path}/public/system/#{fetch(:maintenance_basename, 'maintenance')}.html"
-      upload!(StringIO.new(result), rendered_path)
-      execute "chmod 644 #{rendered_path}"
+      rendered_path = "#{shared_path}/public/system/"
+      rendered_name = "#{fetch(:maintenance_basename, 'maintenance')}.html"
+
+      if test "[ ! -d #{rendered_path} ]"
+        info 'Creating missing directories.'
+        execute :mkdir, '-pv', rendered_path
+      end
+
+      upload!(StringIO.new(result), rendered_path + rendered_name)
+      execute "chmod 644 #{rendered_path + rendered_name}"
     end
   end
 


### PR DESCRIPTION
If the directories to which we upload the maintenance file doesn’t exist, the task fails without any helpful explanation. It’s probably obvious when you think about it, but I did spend quite some time tracking down the reason for the failure.

To get rid of this «bug», the task should test if the directories exist before attempting to upload the file, and create them if necessary.
