### PR TITLE
fix undefined method namespace error by not requrire in Gemfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Add this line to your application's Gemfile:
 
     gem 'capistrano', '~> 3.0'
-    gem 'capistrano-maintenance', github: "capistrano/capistrano-maintenance"
+    gem 'capistrano-maintenance', github: "capistrano/maintenance", require: false 
 
 
 And then execute:


### PR DESCRIPTION
I have following errors when I was using this gem:

> undefined method `namespace' for main:Object (NoMethodError)

And found that I am requiring the wrong repos, and not require in Gemfile so that I can by-pass this namespace error. 

> gem 'capistrano-maintenance', github: "capistrano/maintenance", require: false 

So just update README, in case other follower may confuse when using this gem.
