### PR TITLE
Allow configuration of which roles show maintenance pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,14 @@ The template file should either be a plaintext or an erb file. For example:
 </html>
 ```
 
+By default, the maintenance page will be uploaded to all servers with the `web` role,
+but if your application has different needs, you can customize this using the
+`maintenance_roles` variable:
+
+```
+set :maintenance_roles, -> { roles([:web, :other_role]) }
+```
+
 Further customization will require that you write your own task.
 
 ### Disable task

--- a/lib/capistrano/tasks/maintenance.rake
+++ b/lib/capistrano/tasks/maintenance.rake
@@ -1,7 +1,7 @@
 namespace :maintenance do
   desc "Turn on maintenance mode"
   task :enable do
-    on roles(:web) do
+    on fetch(:maintenance_roles, roles(:web)) do
       require 'erb'
 
       reason = ENV['REASON']
@@ -26,7 +26,7 @@ namespace :maintenance do
 
   desc "Turn off maintenance mode"
   task :disable do
-    on roles(:web) do
+    on fetch(:maintenance_roles, roles(:web)) do
       execute "rm -f #{shared_path}/public/system/#{fetch(:maintenance_basename, 'maintenance')}.html"
     end
   end


### PR DESCRIPTION
In case more roles than `web` require it, you can now select which by
setting the following configuration in your application's capistrano
configuration:

    set :maintenance_roles, -> { roles([:web, :other_role]) }

It's important to defer the evaluation of this setting if you're using
multi-stage deployments.