### PR TITLE
Allow directory of maintenance page to be customized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Reverse chronological order:
 https://github.com/capistrano/capistrano-maintenance/compare/v1.1.0...HEAD
 
 * Your contribution here!
+* [#40](https://github.com/capistrano/maintenance/pull/40): Allow directory of maintenance page to be customized - [@tjwallace](https://github.com/tjwallace).
 
 ## `1.1.0` (2017-01-26)
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ cap maintenance:enable REASON="hardware upgrade" UNTIL="12pm Central Time"
 ```
 
 You can use a different template for the maintenance page by setting the
-`:maintenance_template_path` variable in your deploy.rb file with an absolute path. 
+`:maintenance_template_path` variable in your deploy.rb file with an absolute path.
 
 ```
 set :maintenance_template_path, File.expand_path("../../app/path/to/maintenance.erb.html", __FILE__)
@@ -123,6 +123,14 @@ The template file should either be a plaintext or an erb file. For example:
     <p>It'll be back <%= deadline ? deadline : "shortly" %>.</p>
 </body>
 </html>
+```
+
+You can customize which folder the maintenance page template is rendered to by
+setting the `:maintenance_dirname` variable. By default it renders to
+`"#{shared_path}/public/system"`.
+
+```
+set :maintenance_dirname, -> { "#{current_path}/dist" }
 ```
 
 By default, the maintenance page will be uploaded to all servers with the `web` role,

--- a/lib/capistrano/tasks/maintenance.rake
+++ b/lib/capistrano/tasks/maintenance.rake
@@ -1,33 +1,42 @@
 namespace :maintenance do
   desc "Turn on maintenance mode"
   task :enable do
-    on fetch(:maintenance_roles, roles(:web)) do
+    on fetch(:maintenance_roles) do
       require 'erb'
 
       reason = ENV['REASON']
       deadline = ENV['UNTIL']
 
-      default_template = File.join(File.expand_path('../../templates', __FILE__), 'maintenance.html.erb')
-      template = fetch(:maintenance_template_path, default_template)
-      result = ERB.new(File.read(template)).result(binding)
+      result = ERB.new(File.read(fetch(:maintenance_template_path))).result(binding)
 
-      rendered_path = "#{shared_path}/public/system/"
-      rendered_name = "#{fetch(:maintenance_basename, 'maintenance')}.html"
+      rendered_path = fetch(:maintenance_dirname)
+      rendered_name = "#{fetch(:maintenance_basename)}.html"
 
       if test "[ ! -d #{rendered_path} ]"
         info 'Creating missing directories.'
         execute :mkdir, '-pv', rendered_path
       end
 
-      upload!(StringIO.new(result), rendered_path + rendered_name)
-      execute "chmod 644 #{rendered_path + rendered_name}"
+      rendered_fullpath = "#{rendered_path}/#{rendered_name}"
+      upload! StringIO.new(result), rendered_fullpath
+      execute "chmod 644 #{rendered_fullpath}"
     end
   end
 
   desc "Turn off maintenance mode"
   task :disable do
-    on fetch(:maintenance_roles, roles(:web)) do
-      execute "rm -f #{shared_path}/public/system/#{fetch(:maintenance_basename, 'maintenance')}.html"
+    on fetch(:maintenance_roles) do
+      execute "rm -f #{fetch(:maintenance_dirname)}/#{fetch(:maintenance_basename)}.html"
     end
+  end
+end
+
+namespace :load do
+  task :defaults do
+    set_if_empty :maintenance_roles, -> { roles(:web) }
+    set_if_empty :maintenance_template_path,
+      File.join(File.expand_path('../../templates', __FILE__), 'maintenance.html.erb')
+    set_if_empty :maintenance_dirname, -> { "#{shared_path}/public/system" }
+    set_if_empty :maintenance_basename, 'maintenance'
   end
 end


### PR DESCRIPTION
This allows the directory of the maintenance page to be customized. `"#{shared_path}/public/system/"` is very rails specific.

Also move all defaults to load:defaults task.

This is a duplicate of #28 but it can be currently merged to `master` without conflicts.