### PR TITLE
add an inlining image-helper

### DIFF
--- a/lib/capistrano/tasks/maintenance.rake
+++ b/lib/capistrano/tasks/maintenance.rake
@@ -4,6 +4,13 @@ namespace :maintenance do
     on fetch(:maintenance_roles) do
       require 'erb'
 
+      def inline_image_src(image)
+        file = File.open(image, "rb").read
+        b64 = Base64.encode64(file)
+        extension = File.extname(image)[1..-1]
+        "data:image/#{extension};base64,#{b64}"
+      end
+
       reason = ENV['REASON']
       deadline = ENV['UNTIL']
 


### PR DESCRIPTION
i would like to know if you would consider this useful.

since rails does not provide a simple way to generate get access to the digested asset-urls, i added this helper in order to inline image-data with a maintenance page.

in the erb, just call it like so

```erb
<img src="<%= inline_image_src('app/assets/images/logo.png') %>" />
```
